### PR TITLE
Fixes import of AWS account to cloudability.

### DIFF
--- a/cloudability/resource_linked_account.go
+++ b/cloudability/resource_linked_account.go
@@ -6,8 +6,6 @@ import (
 	"github.com/skyscrapr/cloudability-sdk-go/cloudability"
 	"log"
 	"time"
-	"strings"
-	"fmt"
 	"context"
 )
 

--- a/cloudability/resource_linked_account.go
+++ b/cloudability/resource_linked_account.go
@@ -6,6 +6,9 @@ import (
 	"github.com/skyscrapr/cloudability-sdk-go/cloudability"
 	"log"
 	"time"
+	"strings"
+	"fmt"
+	"context"
 )
 
 func resourceLinkedAccount() *schema.Resource {
@@ -14,7 +17,7 @@ func resourceLinkedAccount() *schema.Resource {
 		Read:   resourceLinkedAccountRead,
 		Delete: resourceLinkedAccountDelete,
 		Importer: &schema.ResourceImporter{
-			StateContext: schema.ImportStatePassthroughContext,
+			StateContext: resourceLinkedAccountImport,
 		},
 		Schema: map[string]*schema.Schema{
 			"vendor_account_name": {
@@ -151,6 +154,7 @@ func resourceLinkedAccountRead(d *schema.ResourceData, meta interface{}) error {
 			return err
 		}
 	}
+	log.Printf("[DEBUG] resourceLinkedAccountRead Account: %v", account)
 
 	if account != nil {
 		d.Set("vendor_account_name", account.VendorAccountName)
@@ -158,7 +162,12 @@ func resourceLinkedAccountRead(d *schema.ResourceData, meta interface{}) error {
 		d.Set("vendor_key", account.VendorKey)
 		d.Set("verification", flattenVerification(account.Verification))
 		d.Set("authorization", flattenAuthorization(account.Authorization))
-		d.Set("external_id", account.Authorization.ExternalID)
+		// when account is fresh in cloudability, it may not have external ID assigned yet
+    if account.Authorization != nil {
+			d.Set("external_id", account.Authorization.ExternalID)
+		} else {
+			log.Print("[DEBUG] resourceLinkedAccountRead Account has no authorization yet")
+		}
 		d.Set("parent_account_id", account.ParentAccountID)
 		d.Set("created_at", account.CreatedAt)
 		d.SetId(account.ID)
@@ -173,4 +182,19 @@ func resourceLinkedAccountDelete(d *schema.ResourceData, meta interface{}) error
 	accountID := d.Get("vendor_account_id").(string)
 	err := client.Vendors().DeleteAccount(vendorKey, accountID)
 	return err
+}
+
+func resourceLinkedAccountImport(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	// Set the vendor key and account ID in the resource data
+	d.Set("vendor_key", "aws")
+	d.Set("vendor_account_id", d.Id())
+	d.Set("type", "aws_role")
+
+	// Call the read function to get the rest of the resource data
+	err := resourceLinkedAccountRead(d, meta)
+	if err != nil {
+		return nil, err
+	}
+
+	return []*schema.ResourceData{d}, nil
 }


### PR DESCRIPTION
# Description of changes

* Allows import of AWS accounts into the state using an import function.
* Fixes a bug when apply fails with nil error, stack trace we received is below. Essentially Cloudability API may not sometimes return authorization, 

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x20 pc=0xae7ed5]
goroutine 87 [running]:
github.com/skyscrapr/terraform-provider-cloudability/cloudability.resourceLinkedAccountRead(0xc87a2a?, {0xc42ee0?, 0xc000502680})
	github.com/skyscrapr/terraform-provider-cloudability/cloudability/resource_linked_account.go:161 +0x775
github.com/skyscrapr/terraform-provider-cloudability/cloudability.resourceLinkedAccountCreate(0x0?, {0xc42ee0?, 0xc000502680?})
	github.com/skyscrapr/terraform-provider-cloudability/cloudability/resource_linked_account.go:133 +0x2d2
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*Resource).create(0xd93040?, {0xd93040?, 0xc0006d0540?}, 0xd?, {0xc42ee0?, 0xc000502680?})
	github.com/hashicorp/terraform-plugin-sdk/v2@v2.27.0/helper/schema/resource.go:721 +0x178
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*Resource).Apply(0xc000151420, {0xd93040, 0xc0006d0540}, 0xc000170a90, 0xc0005a0700, {0xc42ee0, 0xc000502680})
	github.com/hashicorp/terraform-plugin-sdk/v2@v2.27.0/helper/schema/resource.go:864 +0xa85
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*GRPCProviderServer).ApplyResourceChange(0xc000417e00, {0xd93040?, 0xc0006d0420?}, 0xc000265ef0)
	github.com/hashicorp/terraform-plugin-sdk/v2@v2.27.0/helper/schema/grpc_provider.go:1024 +0xe8d
github.com/hashicorp/terraform-plugin-go/tfprotov5/tf5server.(*server).ApplyResourceChange(0xc000258be0, {0xd93040?, 0xc0006ada10?}, 0xc0001baa10)
	github.com/hashicorp/terraform-plugin-go@v0.18.0/tfprotov5/tf5server/server.go:821 +0x574
github.com/hashicorp/terraform-plugin-go/tfprotov5/internal/tfplugin5._Provider_ApplyResourceChange_Handler({0xc30f20?, 0xc000258be0}, {0xd93040, 0xc0006ada10}, 0xc0001ba9a0, 0x0)
	github.com/hashicorp/terraform-plugin-go@v0.18.0/tfprotov5/internal/tfplugin5/tfplugin5_grpc.pb.go:422 +0x170
google.golang.org/grpc.(*Server).processUnaryRPC(0xc0002541e0, {0xd96c00, 0xc00031c4e0}, 0xc0006bca20, 0xc000428f60, 0x1248b00, 0x0)
	google.golang.org/grpc@v1.57.0/server.go:1360 +0xe23
google.golang.org/grpc.(*Server).handleStream(0xc0002541e0, {0xd96c00, 0xc00031c4e0}, 0xc0006bca20, 0x0)
	google.golang.org/grpc@v1.57.0/server.go:1737 +0xa2f
google.golang.org/grpc.(*Server).serveStreams.func1.1()
	google.golang.org/grpc@v1.57.0/server.go:982 +0x98
created by google.golang.org/grpc.(*Server).serveStreams.func1
	google.golang.org/grpc@v1.57.0/server.go:980 +0x18c
Error: The terraform-provider-cloudability_v0.0.35 plugin crashed!
```